### PR TITLE
added Gaussian arbitrary-dimensional prior

### DIFF
--- a/PhysTools/likelihood/likelihood.h
+++ b/PhysTools/likelihood/likelihood.h
@@ -38,12 +38,11 @@
 #include "../autodiff.h"
 #include "../ThreadPool.h"
 
-
-namespace ublas = boost::numeric::ublas;
-
 namespace phys_tools{
 ///Tools for performing binned maximum likelihood fits
 namespace likelihood{
+
+    namespace ublas = boost::numeric::ublas;
 
 	//some useful type traits
 	template<typename T>

--- a/PhysTools/likelihood/likelihood.h
+++ b/PhysTools/likelihood/likelihood.h
@@ -2397,16 +2397,15 @@ namespace likelihood{
         */
     private:   
         // these are matrices rather than vectors, makes it easier!
-        ublas::vector<double> *means = new ublas::vector<double>(_size);
-        ublas::vector<double> *stddevs = new ublas::vector<double>(_size);
+        std::shared_ptr<ublas::vector<double>> means =  std::make_shared<ublas::vector<double>>( ublas::vector<double>(_size));
+        std::shared_ptr<ublas::vector<double>> stddevs =  std::make_shared<ublas::vector<double>>( ublas::vector<double>(_size));
+        std::shared_ptr<ublas::matrix<double>> correlations =  std::make_shared<ublas::matrix<double>>( ublas::matrix<double>(_size, _size));
+        std::shared_ptr<ublas::matrix<double>> inverse =  std::make_shared<ublas::matrix<double>>( ublas::matrix<double>(_size, _size)); 
 
         double determinant;
         double lnorm;
     public:
-        ublas::matrix<double> *correlations = new ublas::matrix<double>(_size, _size);
-        ublas::matrix<double> *inverse = new ublas::matrix<double>(_size, _size); 
         
-
         GaussianNDPrior(std::vector<double>& _means, std::vector<double>& _stddevs, std::vector<std::vector<double>>& _correlations){
             /*
                 We need to calculate the determinant of this 2D matrix, and we need to verify the lengths of these arrays are the right shape! 

--- a/test/gaussian_nd.test.cpp
+++ b/test/gaussian_nd.test.cpp
@@ -1,0 +1,51 @@
+#include <PhysTools/likelihood/likelihood.h>
+#include <iostream>
+#include <vector>
+#include <stdexcept>
+#include <random>
+
+
+bool double_compare(double x, double y){
+    double diff = std::abs(x-y);
+    double eps=(1e-6);
+    return (diff<eps);
+}
+
+int main(int argc, char** argv){
+    /*
+    Checking the 2D case against the known working Gaussian 2D prior
+    */
+
+
+    using namespace phys_tools::likelihood;
+
+    // these are chosen to mimic the Snowstorm effective gradients used in MEOWS
+    double alpha = 0.05091035738186185100;
+    std::vector<std::vector<double>> corr{{1, alpha},
+                                          {alpha, 1}};
+    std::vector<double> means{0.0, 0.0};
+    std::vector<double> sigmas{1.0, 1.0};
+
+    const size_t n_vals = static_cast<size_t>(2);
+
+    GaussianNDPrior<2> testprio(means, sigmas, corr);
+    Gaussian2DPrior otherprio(means[0], means[1], sigmas[0], sigmas[1], alpha);
+
+    std::vector<double> test_values = {0,0.5,1.0,1.5,2.0,2.5};
+
+    for (unsigned int i=0; i<test_values.size(); i++){
+        for (unsigned int j=0; j<test_values.size(); j++){
+        
+        std::vector<double> this_test = {test_values[i], test_values[j]};
+            auto result = testprio(this_test);
+            auto other = otherprio(test_values[i], test_values[j]);
+            bool are_equal = double_compare(result, other);
+            if (!are_equal){
+                throw std::runtime_error("Test failed!");
+            }
+
+        }
+    }
+    return 0;
+
+}


### PR DESCRIPTION
Added in an arbitrary dimensional Gaussian prior for when there are more than two correlated nuisance parameters. 

Also added in a test file to make sure this works; so far I've been able to verify that it agrees with the Gaussian 2D prior for the covariance matrix used in the MEOWS analysis' effective ice gradients. 